### PR TITLE
feat/Aula-03: Criação componente de listagem de Produtos

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import Header from './components/Header';
+import Products from './components/Products';
 
 
 function App() {
   return (
     <div>
       <Header/>
+      <Products />
     </div>
   );
 }

--- a/src/api/fetchProducts.js
+++ b/src/api/fetchProducts.js
@@ -1,0 +1,9 @@
+const fetchProducts = async (query) => {
+  const response = await fetch(`https://api.mercadolibre.com/sites/MLB/search?q=${query}`);
+
+  const data = await response.json();
+
+  return data.results;
+}
+
+export default fetchProducts;

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -2,6 +2,7 @@
   background-color: #fff159;
   position: fixed;
   width: 100%;
+  z-index: 1;
 }
 
 .header > div {

--- a/src/components/ProductCard/ProductCard.css
+++ b/src/components/ProductCard/ProductCard.css
@@ -1,0 +1,71 @@
+.product-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  
+  transition: 0.5s;
+  cursor: pointer;
+
+  width: 100%;
+  max-width: 300px;
+
+  background-color: white;
+  margin: 0 auto;
+}
+
+.product-card:hover {
+  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.1);
+}
+
+.card_image {
+  width: 100%;
+  height: 100%;
+  max-height: 300px;
+  object-fit: contain;
+}
+
+.card_infos {
+  padding: 20px;
+  border-top: 1px solid #ddd;
+}
+
+.card_price {
+  font-size: 30px;
+  font-weight: 400px;
+  display: block;
+  margin-bottom: 10px;
+}
+
+.card_title {
+  font-size: 15px;
+  font-weight: 500px;
+  color: rgba(0, 0, 0 ,0.5);
+  list-style: 1.5;
+}
+
+.card_btn {
+  position: absolute;
+  top: 0;
+  right: 0;
+  opacity: 0;
+  transition: 0.5s;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  cursor: pointer;
+  width: 45px;
+  height: 45px;
+  border-radius: 50%;
+  margin: 12px 15px;
+  color: #0c5dd6;
+  border: none;
+  background-color: rgba(255, 255, 255 ,0.8); 
+
+  font-size: 1.5rem;
+}
+
+.product-card:hover .card_btn {
+  opacity: 1;
+}

--- a/src/components/ProductCard/index.jsx
+++ b/src/components/ProductCard/index.jsx
@@ -1,0 +1,37 @@
+import React from "react";
+import propTypes from "prop-types"
+import { BsFillCartPlusFill } from "react-icons/bs";
+
+import formatCurrency from "../../utils/formatCurrency";
+
+import './ProductCard.css'
+
+function ProductCard({ product }) {
+  const { title, price, thumbnail } = product;
+  return (
+    <section className='product-card'>
+      <img 
+        src={thumbnail.replace(/\w\.jpg/gi, "W.jpg")} 
+        alt="product" 
+        className="card_image" 
+      />
+      <div className="card_infos">
+        <p className="card_price">
+          {formatCurrency(price)}
+        </p>
+        <h2 className="card_title">{title}</h2>
+      </div>
+      <button type="button" className="card_btn">
+        <BsFillCartPlusFill />
+      </button>
+    </section>
+  );
+}
+
+export default ProductCard;
+
+ProductCard.propTypes = {
+  product: propTypes.shape({
+
+  })
+}.isRequired;

--- a/src/components/Products/Products.css
+++ b/src/components/Products/Products.css
@@ -1,0 +1,7 @@
+.products {
+  padding: 120px 20px 50px;
+
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 20px;
+}

--- a/src/components/Products/index.jsx
+++ b/src/components/Products/index.jsx
@@ -1,0 +1,21 @@
+import React, { useState, useEffect } from 'react';
+
+import './Products.css'
+import fetchProducts from '../../api/fetchProducts';
+import ProductCard from '../ProductCard';
+
+function Products() {
+  const [products, setProducts] = useState([]);
+
+  useEffect(() => {
+    fetchProducts('iphone').then((response) => setProducts(response));
+  }, [])
+  
+  return (
+    <section className='products container'>
+      {products.map((product) => <ProductCard key={product.id} product={product}/>)}
+    </section>
+  );
+}
+
+export default Products;

--- a/src/utils/formatCurrency.js
+++ b/src/utils/formatCurrency.js
@@ -1,0 +1,8 @@
+const formatCurrency = (value, currency='BRL') => {
+  return value.toLocaleString('pt-br', {
+    style: 'currency',
+    currency,
+  })
+};
+
+export default formatCurrency;


### PR DESCRIPTION
# Criação componente Header
Na terceira aula, foi criado o componente de listagem dos **Produtos**, com as suas respectivas dependências. 

Foi realizada uma integração com a api do **Mercado livre**, que está retornando dados de produtos pesquisados a partir de uma query. Esse produtos são desencapsulados pelos cards, e seus dados são exibidos (imagem, preço e nome). Estes são ainda tratados, sendo a imagem alterada para sua versão de maior qualidade e o preço formatado como _currency BRL_.

Esse componente apresenta os cards de produtos em um grid, com a seguinte estilização:
```
.products {
  padding: 120px 20px 50px;

  display: grid;
  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
  gap: 20px;
}
```
Com ela, os items são separados com colunas com a propriedade auto-fill, que ocupa o espaço disponível. O tamanho em si de cada coluna é limitado pelas dimensões de 200px e 1fr, garantindo maior responsividade em diferentes dispositivos.

![image](https://github.com/user-attachments/assets/4202be2e-1694-4f1c-97dc-2c1d493b13f0)
